### PR TITLE
SIZE_CLASSES data already ensures correct size for superblocks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ liblrmalloc.so: $(OBJFILES)
 liblrmalloc.a: $(OBJFILES)
 	ar rcs liblrmalloc.a $(OBJFILES)
 
-all_tests: default basic.test
+all_tests: default basic.test size_class_data.test
 
 %.test : test/%.cpp
 	$(CCX) $(DFLAGS) -o $@ $< liblrmalloc.a $(LDFLAGS)

--- a/size_classes.cpp
+++ b/size_classes.cpp
@@ -20,26 +20,6 @@ size_t SizeClassLookup[MAX_SZ + 1] = { 0 };
 
 void InitSizeClass()
 {
-    // each superblock has to contain several blocks
-    // and it has to contain blocks *perfectly*
-    //  e.g no space left after last block
-    for (size_t scIdx = 1; scIdx < MAX_SZ_IDX; ++scIdx) {
-        SizeClassData& sc = SizeClasses[scIdx];
-        size_t blockSize = sc.blockSize;
-        size_t sbSize = sc.sbSize;
-        // size class large enough to store several elements
-        if (sbSize > blockSize && (sbSize % blockSize) == 0) {
-            continue; // skip
-        }
-
-        // increase superblock size so it can hold >1 elements
-        while (blockSize >= sbSize) {
-            sbSize += sc.sbSize;
-        }
-
-        sc.sbSize = sbSize;
-    }
-
     // increase superblock size if need
     for (size_t scIdx = 1; scIdx < MAX_SZ_IDX; ++scIdx) {
         SizeClassData& sc = SizeClasses[scIdx];

--- a/size_classes.h
+++ b/size_classes.h
@@ -92,15 +92,15 @@ inline size_t GetSizeClass(size_t size)
     SC(28, 11, 9, 1, no, yes, 5, 9)                                       \
     SC(29, 11, 9, 2, no, yes, 3, 9)                                       \
     SC(30, 11, 9, 3, no, yes, 7, 9)                                       \
-    SC(31, 11, 9, 4, yes, yes, 1, 9)                                      \
+    SC(31, 11, 9, 4, yes, yes, 2, 9)                                      \
                                                                           \
     SC(32, 12, 10, 1, no, yes, 5, no)                                     \
     SC(33, 12, 10, 2, no, yes, 3, no)                                     \
     SC(34, 12, 10, 3, no, yes, 7, no)                                     \
-    SC(35, 12, 10, 4, yes, yes, 2, no)                                    \
+    SC(35, 12, 10, 4, yes, yes, 4, no)                                    \
                                                                           \
     SC(36, 13, 11, 1, no, yes, 5, no)                                     \
-    SC(37, 13, 11, 2, yes, yes, 3, no)                                    \
+    SC(37, 13, 11, 2, yes, yes, 6, no)                                    \
     SC(38, 13, 11, 3, no, yes, 7, no)                                     \
     SC(39, 13, 11, 4, yes, no, 0, no)                                     \
                                                                           \

--- a/test/size_class_data.cpp
+++ b/test/size_class_data.cpp
@@ -1,0 +1,25 @@
+#include <cassert>
+
+#include "../size_classes.h"
+
+#define SIZE_CLASS_bin_yes(blockSize, pages) { blockSize, pages * PAGE },
+#define SIZE_CLASS_bin_no(blockSize, pages)
+
+#define SC(index, lg_grp, lg_delta, ndelta, psz, bin, pgs, lg_delta_lookup) \
+    SIZE_CLASS_bin_##bin((1U << lg_grp) + (ndelta << lg_delta), pgs)
+
+
+int main()
+{
+    SizeClassData SizeClasses[MAX_SZ_IDX] = { { 0, 0 }, SIZE_CLASSES };
+    // each superblock has to contain several blocks
+    // and it has to contain blocks *perfectly*
+    //  e.g no space left after last block
+    for (size_t scIdx = 1; scIdx < MAX_SZ_IDX; ++scIdx) {
+        SizeClassData& sc = SizeClasses[scIdx];
+        // size class large enough to store several elements
+        assert(sc.sbSize >= (sc.blockSize * 2));
+        assert((sc.sbSize % sc.blockSize) == 0);
+        assert(sc.sbSize < (PAGE * PAGE));
+    }
+}


### PR DESCRIPTION
The exact number of pages required by each superblock type is described in the data, so there is no need to calculate it.