### PR TITLE
Prevent pagemap from being included in core dumps

### DIFF
--- a/pages.cpp
+++ b/pages.cpp
@@ -30,6 +30,9 @@ void* PageAllocOvercommit(size_t size)
     void* ptr = mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON | MAP_NORESERVE, -1, 0);
     if (ptr == MAP_FAILED) {
         ptr = nullptr;
+    } else {
+        // exclude such large maps from core dumps as they become unusable otherwise
+        madvise(ptr, size, MADV_DONTDUMP);
     }
 
     return ptr;


### PR DESCRIPTION
The page map is too large and sparsely populated to be dumped. This is not ideal but much better than a 2TiB core dump. Maybe one day the kernel will be smart enough to not include untouched pages in core dumps