### PR TITLE
Add missing includes

### DIFF
--- a/lrmalloc.h
+++ b/lrmalloc.h
@@ -7,6 +7,8 @@
 #ifndef __LFMALLOC_H
 #define __LFMALLOC_H
 
+#include <stddef.h>
+
 // a cache line is 64 bytes
 #define LG_CACHELINE 6
 // a page is 4KB

--- a/size_classes.cpp
+++ b/size_classes.cpp
@@ -4,6 +4,7 @@
  * details.
  */
 
+#include "lrmalloc_internal.h"
 #include "size_classes.h"
 
 #include "log.h"


### PR DESCRIPTION
Include stddef.h in lrmalloc.h due to use of size_t and lrmalloc_internal.h in size_classes.cpp due to use of MAX_BLOCK_NUM in ASSERT().