### PR TITLE
Change addressing mode for lists in cache

### DIFF
--- a/tcache.h
+++ b/tcache.h
@@ -10,6 +10,7 @@
 #include "log.h"
 #include "lrmalloc.h"
 #include "size_classes.h"
+#include <cstddef>
 
 struct TCacheBin {
 private:
@@ -18,11 +19,11 @@ private:
 
 public:
     // common, fast ops
-    void PushBlock(char* block);
+    void PushBlock(char* block, size_t scIdx);
     // push block list, cache *must* be empty
     void PushList(char* block, uint32_t length);
 
-    char* PopBlock(); // can return nullptr
+    char* PopBlock(size_t scIdx); // can return nullptr
     // manually popped list of blocks and now need to update cache
     // `block` is the new head
     void PopList(char* block, uint32_t length);
@@ -33,10 +34,11 @@ public:
     // slow operations like fill/flush handled in cache user
 };
 
-inline void TCacheBin::PushBlock(char* block)
+inline void TCacheBin::PushBlock(char* block, size_t scIdx)
 {
+    size_t blockSize = SizeClasses[scIdx].blockSize;
     // block has at least sizeof(char*)
-    *(char**)block = _block;
+    *(ptrdiff_t*)block = _block - block - blockSize;
     _block = block;
     _blockNum++;
 }
@@ -51,13 +53,13 @@ inline void TCacheBin::PushList(char* block, uint32_t length)
     _blockNum = length;
 }
 
-inline char* TCacheBin::PopBlock()
+inline char* TCacheBin::PopBlock(size_t scIdx)
 {
     // caller must ensure there's an available block
     ASSERT(_blockNum > 0);
-
+    size_t blockSize = SizeClasses[scIdx].blockSize;
     char* ret = _block;
-    _block = *(char**)_block;
+    _block += *(ptrdiff_t*)_block + blockSize;
     _blockNum--;
     return ret;
 }


### PR DESCRIPTION
By changing the addressing mode we can ensure a freshly allocated superblock of all zeroes is a valid linked list of blocks. This allows us to not touch memory at least until it is freed by the user, at which point it was probably already touched by the user.