### PR TITLE
Make all superblocks the same size and smaller and add a mmap cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ CXXFLAGS=-shared -fPIC -std=gnu++14 -O2 -Wall $(DFLAGS) \
 
 LDFLAGS=-ldl -pthread
 
-OBJFILES=lrmalloc.o size_classes.o pages.o pagemap.o tcache.o thread_hooks.o
+OBJFILES=lrmalloc.o size_classes.o pages.o pagemap.o tcache.o thread_hooks.o mapcache.o
 
 default: liblrmalloc.so liblrmalloc.a
 

--- a/mapcache.cpp
+++ b/mapcache.cpp
@@ -1,0 +1,11 @@
+/*
+ * Copyright (C) 2019 Ricardo Leite. All rights reserved.
+ * Licenced under the MIT licence. See COPYING file in the project root for
+ * details.
+ */
+
+#include "mapcache.h"
+
+// thread cache, uses tsd/tls
+// one cache per thread
+__thread MapCacheBin sMapCache;

--- a/mapcache.h
+++ b/mapcache.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2019 Ricardo Leite. All rights reserved.
+ * Licenced under the MIT licence. See COPYING file in the project root for
+ * details.
+ */
+
+#ifndef __MAPCACHE_H_
+#define __MAPCACHE_H_
+
+#include "log.h"
+#include "pages.h"
+#include "size_classes.h"
+#include <sys/mman.h>
+
+#define MAPCACHE_SIZE 64
+
+struct MapCacheBin {
+private:
+    char* _block = nullptr;
+    uint32_t _blockNum = 0;
+
+public:
+    // Map MAPCACHE_SIZE superblocks in one go and then consume 1 by 1
+    char* Alloc();
+    // Unmap superblocks immediately in SB_SIZE chunks
+    void Free(char*);
+    // Used for thread termination to unmap what remains
+    void Flush();
+};
+
+inline char* MapCacheBin::Alloc()
+{
+    if (_blockNum == 0) {
+        _block = (char*)PageAlloc(SB_SIZE * MAPCACHE_SIZE);
+        if (_block == nullptr) {
+            return nullptr;
+        }
+        _blockNum = MAPCACHE_SIZE;
+    }
+    char* ret = _block;
+    _block += SB_SIZE;
+    _blockNum--;
+    return ret;
+}
+
+inline void MapCacheBin::Free(char* block)
+{
+    PageFree(block, SB_SIZE);
+}
+
+inline void MapCacheBin::Flush()
+{
+    if (_blockNum > 0) {
+        PageFree(_block, SB_SIZE * _blockNum);
+    }
+}
+
+// use tls init exec model
+extern __thread MapCacheBin sMapCache LFMALLOC_TLS_INIT_EXEC LFMALLOC_CACHE_ALIGNED;
+
+#endif // __MAPCACHE_H_

--- a/size_classes.cpp
+++ b/size_classes.cpp
@@ -21,23 +21,11 @@ size_t SizeClassLookup[MAX_SZ + 1] = { 0 };
 
 void InitSizeClass()
 {
-    // increase superblock size if need
-    for (size_t scIdx = 1; scIdx < MAX_SZ_IDX; ++scIdx) {
-        SizeClassData& sc = SizeClasses[scIdx];
-        size_t sbSize = sc.sbSize;
-        // 16MiB
-        while (sbSize < (PAGE * PAGE)) {
-            sbSize += sc.sbSize;
-        }
-
-        sc.sbSize = sbSize;
-    }
-
     // fill blockNum and cacheBlockNum
     for (size_t scIdx = 1; scIdx < MAX_SZ_IDX; ++scIdx) {
         SizeClassData& sc = SizeClasses[scIdx];
         // blockNum calc
-        sc.blockNum = sc.sbSize / sc.blockSize;
+        sc.blockNum = SB_SIZE / sc.blockSize;
         // cacheBlockNum calc
         sc.cacheBlockNum = sc.blockNum * 1;
         ASSERT(sc.blockNum > 0);

--- a/size_classes.h
+++ b/size_classes.h
@@ -19,16 +19,14 @@
 // last size covered by a size class
 // allocations with size > MAX_SZ are not covered by a size class
 #define MAX_SZ ((1 << 13) + (1 << 11) * 3)
+#define SB_SIZE 1024 * 256
 
 // contains size classes
 struct SizeClassData {
 public:
     // size of block
     uint32_t blockSize;
-    // superblock size
-    // always a multiple of page size
-    uint32_t sbSize;
-    // cached number of blocks, equal to sbSize / blockSize
+    // cached number of blocks, equal to SB_SIZE / blockSize
     uint32_t blockNum;
     // number of blocks held by thread-specific caches
     uint32_t cacheBlockNum;

--- a/test/size_class_data.cpp
+++ b/test/size_class_data.cpp
@@ -18,8 +18,6 @@ int main()
     for (size_t scIdx = 1; scIdx < MAX_SZ_IDX; ++scIdx) {
         SizeClassData& sc = SizeClasses[scIdx];
         // size class large enough to store several elements
-        assert(sc.sbSize >= (sc.blockSize * 2));
-        assert((sc.sbSize % sc.blockSize) == 0);
-        assert(sc.sbSize < (PAGE * PAGE));
+        assert(SB_SIZE >= (sc.blockSize * 2));
     }
 }

--- a/thread_hooks.cpp
+++ b/thread_hooks.cpp
@@ -10,6 +10,7 @@
 
 #include "size_classes.h"
 #include "tcache.h"
+#include "mapcache.h"
 
 // handle process init/exit hooks
 pthread_key_t destructor_key;
@@ -40,6 +41,7 @@ void lf_malloc_thread_finalize()
     for (size_t scIdx = 1; scIdx < MAX_SZ_IDX; ++scIdx) {
         FlushCache(scIdx, &TCache[scIdx]);
     }
+    sMapCache.Flush();
 }
 
 LFMALLOC_ATTR(constructor)


### PR DESCRIPTION
Simplify superblock size by making them all the same size (comes at a cost of 3% in memory in the worst case)
Reduce superblock/thread cache sizes as it boosts performance in cache flushes when memory is shuffled between threads, but can degrade performance in allocation heavy scenarios
Add mmap cache in order to remove the performance degradation introduced earlier at no cost.